### PR TITLE
Rebuild frontend with code-behind pattern

### DIFF
--- a/ChatApp/ClientServices/ChatClientService.cs
+++ b/ChatApp/ClientServices/ChatClientService.cs
@@ -1,0 +1,80 @@
+using ChatApp.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace ChatApp.ClientServices
+{
+    public class ChatClientService
+    {
+        private readonly HttpClient _http;
+        private readonly NavigationManager _navigation;
+
+        public HubConnection? Connection { get; private set; }
+        public string Token { get; private set; } = string.Empty;
+
+        public event Action<ChatMessageView>? MessageReceived;
+
+        public ChatClientService(HttpClient http, NavigationManager navigation)
+        {
+            _http = http;
+            _navigation = navigation;
+        }
+
+        public async Task<bool> LoginAsync(string email, string password)
+        {
+            var response = await _http.PostAsJsonAsync("auth/login", new LoginRequest { Email = email, Password = password });
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
+                Token = result?.Token ?? string.Empty;
+                await StartConnectionAsync();
+                return true;
+            }
+            return false;
+        }
+
+        public async Task RegisterAsync(string email, string password)
+        {
+            await _http.PostAsJsonAsync("auth/register", new LoginRequest { Email = email, Password = password });
+            await LoginAsync(email, password);
+        }
+
+        private async Task StartConnectionAsync()
+        {
+            Connection = new HubConnectionBuilder()
+                .WithUrl(_navigation.ToAbsoluteUri("/chathub"), options =>
+                {
+                    options.AccessTokenProvider = () => Task.FromResult(Token);
+                })
+                .Build();
+
+            Connection.On<int, string, string, DateTime>("ReceiveMessage", (id, sender, text, ts) =>
+            {
+                MessageReceived?.Invoke(new ChatMessageView { Id = id, SenderId = sender, Text = text, Timestamp = ts, IsPrivate = false });
+            });
+
+            Connection.On<int, string, string, DateTime>("ReceivePrivateMessage", (id, sender, text, ts) =>
+            {
+                MessageReceived?.Invoke(new ChatMessageView { Id = id, SenderId = sender, Text = text, Timestamp = ts, IsPrivate = true });
+            });
+
+            await Connection.StartAsync();
+        }
+
+        public async Task SendMessageAsync(string message, string? receiver)
+        {
+            if (Connection == null || string.IsNullOrWhiteSpace(message)) return;
+
+            await Connection.SendAsync("SendMessage", message, string.IsNullOrWhiteSpace(receiver) ? null : receiver);
+        }
+    }
+
+    public class ChatMessageView
+    {
+        public int Id { get; set; }
+        public string SenderId { get; set; } = string.Empty;
+        public string Text { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public bool IsPrivate { get; set; }
+    }
+}

--- a/ChatApp/Pages/Index.razor
+++ b/ChatApp/Pages/Index.razor
@@ -1,0 +1,30 @@
+@page "/"
+@inject ChatClientService ChatClient
+
+@if (string.IsNullOrEmpty(ChatClient.Token))
+{
+    <h3>Login or Register</h3>
+    <input @bind="Email" placeholder="Email" />
+    <input type="password" @bind="Password" placeholder="Password" />
+    <button class="btn btn-primary" @onclick="Login">Login</button>
+    <button class="btn btn-secondary" @onclick="Register">Register</button>
+}
+else
+{
+    <h1>Chat</h1>
+    @if (!IsConnected)
+    {
+        <p>Connecting...</p>
+    }
+    <div class="chat-window">
+        @foreach (var msg in Messages)
+        {
+            <div class="message @(msg.IsPrivate ? "private" : "public")">
+                <strong>@msg.SenderId</strong> (@msg.Timestamp.ToLocalTime()): @msg.Text
+            </div>
+        }
+    </div>
+    <input @bind="Receiver" placeholder="Recipient Id (blank for all)" />
+    <input @bind="Message" placeholder="Message" @onkeydown="HandleKey" />
+    <button class="btn btn-primary" @onclick="Send">Send</button>
+}

--- a/ChatApp/Pages/Index.razor.cs
+++ b/ChatApp/Pages/Index.razor.cs
@@ -1,0 +1,57 @@
+using ChatApp.ClientServices;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace ChatApp.Pages
+{
+    public partial class Index : ComponentBase
+    {
+        [Inject]
+        private ChatClientService ChatClient { get; set; } = default!;
+
+        private List<ChatMessageView> Messages { get; set; } = new();
+        private string Message { get; set; } = string.Empty;
+        private string Receiver { get; set; } = string.Empty;
+        private string Email { get; set; } = string.Empty;
+        private string Password { get; set; } = string.Empty;
+
+        private bool IsConnected => ChatClient.Connection?.State == HubConnectionState.Connected;
+
+        protected override void OnInitialized()
+        {
+            ChatClient.MessageReceived += OnMessageReceived;
+        }
+
+        private void OnMessageReceived(ChatMessageView msg)
+        {
+            Messages.Add(msg);
+            InvokeAsync(StateHasChanged);
+        }
+
+        private async Task Login()
+        {
+            await ChatClient.LoginAsync(Email, Password);
+        }
+
+        private async Task Register()
+        {
+            await ChatClient.RegisterAsync(Email, Password);
+        }
+
+        private async Task Send()
+        {
+            await ChatClient.SendMessageAsync(Message, Receiver);
+            Message = string.Empty;
+            Receiver = string.Empty;
+        }
+
+        private async Task HandleKey(KeyboardEventArgs e)
+        {
+            if (e.Key == "Enter")
+            {
+                await Send();
+            }
+        }
+    }
+}

--- a/ChatApp/Pages/_Host.cshtml
+++ b/ChatApp/Pages/_Host.cshtml
@@ -1,0 +1,23 @@
+@page "/"
+@namespace ChatApp.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ChatApp</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body>
+    <app>
+        <component type="typeof(App)" render-mode="Server" />
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/ChatApp/Pages/_ViewImports.cshtml
+++ b/ChatApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/ChatApp/Program.cs
+++ b/ChatApp/Program.cs
@@ -2,6 +2,7 @@ using ChatApp.Data;
 using ChatApp.Hubs;
 using ChatApp.Models;
 using ChatApp.Services;
+using ChatApp.ClientServices;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -56,6 +57,7 @@ builder.Services.AddAuthorization();
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddSignalR();
 builder.Services.AddScoped<ChatService>();
+builder.Services.AddScoped<ChatApp.ClientServices.ChatClientService>();
 
 var app = builder.Build();
 

--- a/ChatApp/Shared/LoginDisplay.razor
+++ b/ChatApp/Shared/LoginDisplay.razor
@@ -1,0 +1,13 @@
+@inject NavigationManager Navigation
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+<AuthorizeView>
+    <Authorized>
+        Hello, @context.User.Identity?.Name!
+        <button class="btn btn-link" @onclick="SignOut">Sign out</button>
+    </Authorized>
+    <NotAuthorized>
+        <a class="btn btn-link" href="Identity/Account/Login">Sign in</a>
+    </NotAuthorized>
+</AuthorizeView>

--- a/ChatApp/Shared/LoginDisplay.razor.cs
+++ b/ChatApp/Shared/LoginDisplay.razor.cs
@@ -1,0 +1,24 @@
+using ChatApp.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Identity;
+
+namespace ChatApp.Shared
+{
+    public partial class LoginDisplay : ComponentBase
+    {
+        [Inject]
+        public NavigationManager Navigation { get; set; } = default!;
+
+        [Inject]
+        public SignInManager<ApplicationUser> SignInManager { get; set; } = default!;
+
+        [Inject]
+        public UserManager<ApplicationUser> UserManager { get; set; } = default!;
+
+        private async Task SignOut()
+        {
+            await SignInManager.SignOutAsync();
+            Navigation.NavigateTo("/");
+        }
+    }
+}

--- a/ChatApp/Shared/MainLayout.razor
+++ b/ChatApp/Shared/MainLayout.razor
@@ -1,0 +1,17 @@
+@inherits LayoutComponentBase
+
+<PageTitle>ChatApp</PageTitle>
+
+<div class="page">
+    <header>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+            <a class="navbar-brand" href="/">ChatApp</a>
+            <div class="ml-auto">
+                <LoginDisplay />
+            </div>
+        </nav>
+    </header>
+    <main role="main" class="container mt-3">
+        @Body
+    </main>
+</div>

--- a/ChatApp/_Imports.razor
+++ b/ChatApp/_Imports.razor
@@ -10,3 +10,4 @@
 @using ChatApp
 @using ChatApp.Shared
 @using ChatApp.Models
+@using ChatApp.ClientServices


### PR DESCRIPTION
## Summary
- add `ChatClientService` for front‑end logic
- create Blazor pages with code behind (`Index.razor` and `.razor.cs`)
- restore host and view import Razor files
- add shared components with code-behind
- register new service in `Program.cs`

## Testing
- `dotnet build ChatApp/ChatApp.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed12bb1483309bea595f71e0089b