### PR TITLE
Fix duplicate injection after frontend rewrite

### DIFF
--- a/ChatApp/Pages/Index.razor
+++ b/ChatApp/Pages/Index.razor
@@ -1,5 +1,5 @@
 @page "/"
-@inject ChatClientService ChatClient
+@* Service injected via code-behind *@
 
 @if (string.IsNullOrEmpty(ChatClient.Token))
 {

--- a/ChatApp/Shared/LoginDisplay.razor
+++ b/ChatApp/Shared/LoginDisplay.razor
@@ -1,6 +1,4 @@
-@inject NavigationManager Navigation
-@inject SignInManager<ApplicationUser> SignInManager
-@inject UserManager<ApplicationUser> UserManager
+@* Services injected via code-behind *@
 
 <AuthorizeView>
     <Authorized>


### PR DESCRIPTION
## Summary
- resolve build errors in `Index` and `LoginDisplay` by removing duplicate
  `@inject` declarations

## Testing
- `dotnet build testingground.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6880f55fcdf8833091264f748ed6d29d