### PR TITLE
Fix ChatClient service injection

### DIFF
--- a/ChatApp/ClientServices/ChatClientService.cs
+++ b/ChatApp/ClientServices/ChatClientService.cs
@@ -1,6 +1,7 @@
 using ChatApp.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
+using System.Net.Http;
 
 namespace ChatApp.ClientServices
 {
@@ -14,15 +15,15 @@ namespace ChatApp.ClientServices
 
         public event Action<ChatMessageView>? MessageReceived;
 
-        public ChatClientService(HttpClient http, NavigationManager navigation)
+        public ChatClientService(IHttpClientFactory factory, NavigationManager navigation)
         {
-            _http = http;
             _navigation = navigation;
+            _http = factory.CreateClient();
         }
 
         public async Task<bool> LoginAsync(string email, string password)
         {
-            var response = await _http.PostAsJsonAsync("auth/login", new LoginRequest { Email = email, Password = password });
+            var response = await _http.PostAsJsonAsync(_navigation.ToAbsoluteUri("auth/login"), new LoginRequest { Email = email, Password = password });
             if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadFromJsonAsync<LoginResponse>();
@@ -35,7 +36,7 @@ namespace ChatApp.ClientServices
 
         public async Task RegisterAsync(string email, string password)
         {
-            await _http.PostAsJsonAsync("auth/register", new LoginRequest { Email = email, Password = password });
+            await _http.PostAsJsonAsync(_navigation.ToAbsoluteUri("auth/register"), new LoginRequest { Email = email, Password = password });
             await LoginAsync(email, password);
         }
 

--- a/ChatApp/Program.cs
+++ b/ChatApp/Program.cs
@@ -14,6 +14,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddControllers();
+builder.Services.AddHttpClient();
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlite("Data Source=chatapp.db"));


### PR DESCRIPTION
## Summary
- register HttpClient and use it from ChatClientService via factory
- build absolute URLs when authenticating

## Testing
- `dotnet build ChatApp/ChatApp.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6880f8fb25c883309c2a1e6bf99fadf4